### PR TITLE
Fix unescaped hyphen in coffeescript

### DIFF
--- a/coffeescript.nanorc
+++ b/coffeescript.nanorc
@@ -1,7 +1,7 @@
 syntax "coffeescript" "\.coffee$"
 header "^#!.*/(env +)?coffee"
 
-OPERATOR: "[!&|=/*+-<>]|\<(and|or|is|isnt|not)\>"
+OPERATOR: "[!&|=/*+\-<>]|\<(and|or|is|isnt|not)\>"
 FUNCTION: "[A-Za-z_][A-Za-z0-9_]*:[[:space:]]*(->|\()" "->"
 PLAIN:    "[()]"
 KEYWORD:  "\<(for|of|continue|break|isnt|null|unless|this|else|if|return)\>"


### PR DESCRIPTION
This prevents nano from reporting error when you have included coffeescript.nanorc or ALL.nanorc.
