### PR TITLE
Add async/await keywords (new in Python 3.5) to the Python syntax

### DIFF
--- a/python.nanorc
+++ b/python.nanorc
@@ -1,8 +1,8 @@
 syntax "python" "\.py$" "jhbuildrc$"
 header "^#!.*/(env +)?python[-0-9._]*( |$)"
 
-KEYWORD:  "\<(as|assert|break|class|continue|def|del|elif|else|except)\>"
-KEYWORD:  "\<(exec|finally|for|from|global|if|import|lambda)\>"
+KEYWORD:  "\<(as|assert|async|await|break|class|continue|def|del|elif)\>"
+KEYWORD:  "\<(else|except|exec|finally|for|from|global|if|import|lambda)\>"
 KEYWORD:  "\<(pass|print|raise|return|try|while|with|yield|None)\>"
 +FUNCTION
 OPERATOR: "[-+*/|=%<>&~^]|\<(and|not|or|is|in)\>"


### PR DESCRIPTION
Python 3.5 adds two new keywords:  `async` and `await`
